### PR TITLE
Improve README with project overview and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# darkrai
-# darkrai
+# Darkrai
+
+Darkrai is an experimental project aiming to create a command-line tool for generating fantasy worlds in a structured JSON format. The core feature will leverage the Mistral large language model (LLM) to autonomously produce a world's geography, environment, and points of interest. This README outlines the project goals, planned JSON schema, setup steps, and how the generator can be run once implemented.
+
+## Project Goals
+
+- Build a simple world generator that interacts with the Mistral LLM.
+- Produce output in a standard JSON structure so that clients can easily parse or display the generated world.
+- Provide a command-line interface for users to initiate world creation and save the resulting JSON to disk.
+
+### Planned JSON Format
+
+The generator will eventually emit a JSON object similar to the example below:
+
+```json
+{
+  "world": {
+    "name": "string",
+    "description": "string",
+    "regions": [
+      {
+        "name": "string",
+        "biome": "string",
+        "points_of_interest": ["string", "string"]
+      }
+    ]
+  }
+}
+```
+
+The format may evolve during development.
+
+## Setup
+
+The repository currently contains only this documentation, but it is intended to be a Python package. To prepare a development environment:
+
+1. Ensure Python 3.11 or higher is installed.
+2. Create and activate a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+3. Install dependencies once they are defined in `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Dependencies
+
+Planned dependencies include:
+
+- `mistral-client` (or an equivalent library) to communicate with the Mistral LLM.
+- Standard Python modules such as `json`, `argparse`, and `logging`.
+
+A complete list will be added as implementation progresses.
+
+## Running the Generator
+
+Implementation of the generator is forthcoming. Once available, you will be able to run a command like:
+
+```bash
+python -m darkrai.generate --output world.json
+```
+
+This will request world data from the Mistral LLM, then save the JSON output to `world.json`.
+
+---
+
+This project is in its early stages, and contributions are welcome as we work toward a fully functional generator.


### PR DESCRIPTION
## Summary
- expand README with an overview of the Darkrai project
- outline the world generator goals and planned JSON format
- add basic setup steps, dependencies, and usage example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c69672fd4832ba1a70305d2a0ea71