### PR TITLE
Add Mistral client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # darkrai
-# darkrai
+
+Utilities for generating world data using Mistral models.
+
+## Installation
+
+```
+pip install -r requirements.txt
+```
+
+The package depends on `requests` and optionally `transformers` if you want to use a local checkpoint.
+
+## Usage
+
+The `MistralClient` can call the hosted Mistral API or load a local model checkpoint.
+
+### Using the API
+
+```python
+from darkrai.mistral_client import MistralClient
+
+client = MistralClient(api_key="YOUR_API_KEY")
+world = client.generate_world("Create a fantasy world with two kingdoms")
+print(world)
+```
+
+### Using a local checkpoint
+
+```python
+from darkrai.mistral_client import MistralClient
+
+client = MistralClient(checkpoint="/path/to/checkpoint")
+world = client.generate_world("Create a fantasy world with two kingdoms")
+print(world)
+```
+
+The model is expected to return a JSON string which will be parsed into a Python dictionary.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+transformers>=4.0.0

--- a/src/darkrai/__init__.py
+++ b/src/darkrai/__init__.py
@@ -1,0 +1,5 @@
+"""darkrai package."""
+
+from .mistral_client import MistralClient
+
+__all__ = ["MistralClient"]

--- a/src/darkrai/mistral_client.py
+++ b/src/darkrai/mistral_client.py
@@ -1,0 +1,64 @@
+import os
+import json
+from typing import Any, Dict, Optional
+
+import requests
+
+try:
+    from transformers import AutoTokenizer, AutoModelForCausalLM
+except ImportError:  # pragma: no cover - transformers is optional
+    AutoTokenizer = None
+    AutoModelForCausalLM = None
+
+
+class MistralClient:
+    """Client for interacting with the Mistral model via API or local checkpoint."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "mistral-7b", checkpoint: Optional[str] = None):
+        self.api_key = api_key or os.getenv("MISTRAL_API_KEY")
+        self.model = model
+        self.checkpoint = checkpoint
+        self.session = requests.Session()
+
+        if checkpoint:
+            if AutoTokenizer is None or AutoModelForCausalLM is None:
+                raise ImportError("transformers is required for using local checkpoints")
+            self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+            self.local_model = AutoModelForCausalLM.from_pretrained(checkpoint)
+        else:
+            if not self.api_key:
+                raise ValueError("API key must be provided via argument or MISTRAL_API_KEY environment variable")
+            self.local_model = None
+
+    def _call_api(self, prompt: str, **kwargs: Any) -> str:
+        url = "https://api.mistral.ai/v1/chat/completions"
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        payload.update(kwargs)
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = self.session.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+
+    def _call_local(self, prompt: str, **kwargs: Any) -> str:
+        if not self.local_model:
+            raise RuntimeError("Local model not configured")
+        inputs = self.tokenizer(prompt, return_tensors="pt")
+        output_ids = self.local_model.generate(**inputs, **kwargs)
+        return self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
+
+    def generate_world(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        """Generate world data from a prompt.
+
+        The model is expected to return a JSON string describing the world.
+        This method parses the string into a Python dictionary.
+        """
+        text = self._call_local(prompt, **kwargs) if self.checkpoint else self._call_api(prompt, **kwargs)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Model output is not valid JSON: {text}") from exc
+


### PR DESCRIPTION
## Summary
- add a small Python package under `src/darkrai`
- implement `MistralClient` for calling the Mistral API or a local checkpoint
- document usage in `README`
- include minimal `requirements.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c6966fe70832b89a0b895fbab916e