### PR TITLE
Add CLI world generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ The model is expected to return a JSON string which will be parsed into a Python
 
 ## Running the Generator
 
-Implementation of the generator is forthcoming. Once available, you will be able to run a command like:
+You can now generate a world using `scripts/generate_world.py`:
 
 ```bash
-python -m darkrai.generate --output world.json
+python scripts/generate_world.py "<prompt>" --output world.json
 ```
 
 This will request world data from the Mistral LLM, then save the JSON output to `world.json`.

--- a/scripts/generate_world.py
+++ b/scripts/generate_world.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Command-line interface for generating a world using Mistral."""
+
+import argparse
+import json
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a fantasy world using the Mistral model")
+    parser.add_argument("prompt", help="Prompt describing the world to generate")
+    parser.add_argument("-o", "--output", help="Output file path. If omitted, prints to stdout")
+    parser.add_argument("--api-key", help="API key for Mistral. Defaults to MISTRAL_API_KEY env var")
+    parser.add_argument("--model", default="mistral-7b", help="Model name to use (default: mistral-7b)")
+    parser.add_argument("--checkpoint", help="Path to local checkpoint instead of using API")
+
+    args = parser.parse_args()
+
+    from darkrai import MistralClient
+    client = MistralClient(api_key=args.api_key, model=args.model, checkpoint=args.checkpoint)
+    world = client.generate_world(args.prompt)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(world, f, indent=2)
+    else:
+        json.dump(world, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI utility at `scripts/generate_world.py`
- document running the new script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca21e9594832b86f547317578e109