### PR TITLE
Add script for downloading Mistral model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+models/

--- a/README.md
+++ b/README.md
@@ -48,12 +48,19 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+4. *(Optional)* Download the Mistral 7B model checkpoint for local generation:
+
+```bash
+python scripts/download_model.py
+```
+
 ### Dependencies
 
 Planned dependencies include:
 
 - `mistral-client` (or an equivalent library) to communicate with the Mistral LLM.
 - Standard Python modules such as `json`, `argparse`, and `logging`.
+- `huggingface-hub` for downloading checkpoints from Hugging Face.
 
 A complete list will be added as implementation progresses.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 transformers>=4.0.0
+huggingface-hub>=0.17.0

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Download the Mistral 7B model from Hugging Face."""
+
+import argparse
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download the Mistral 7B model from Hugging Face"
+    )
+    parser.add_argument(
+        "--repo-id",
+        default="mistralai/Mistral-7B-v0.1",
+        help="Hugging Face repository id for the model",
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        default="models/mistral-7b",
+        help="Directory to download the model into",
+    )
+
+    args = parser.parse_args()
+
+    dest = Path(args.destination).expanduser().resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    snapshot_download(
+        repo_id=args.repo_id,
+        local_dir=str(dest),
+        local_dir_use_symlinks=False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script to download Mistral 7B from Hugging Face
- document model download in setup instructions
- ignore downloaded models
- add huggingface-hub to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca686d1d8832b9a9eae5e343b45c9