### PR TITLE
Fix CLI and remove requests dependency

### DIFF
--- a/src/darkrai/cli.py
+++ b/src/darkrai/cli.py
@@ -11,7 +11,13 @@ from .mistral_client import MistralClient
 
 
 def _cmd_generate(args: argparse.Namespace) -> None:
-    client = MistralClient(checkpoint="../../../models/mistral-7b")
+    """Handle the ``generate`` subcommand."""
+
+    client = MistralClient(
+        api_key=args.api_key,
+        model=args.model,
+        checkpoint=args.checkpoint,
+    )
     world = client.generate_world(args.prompt)
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- make CLI `generate` honor command-line options
- allow `MistralClient` to operate without the `requests` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd45e8004832b83e3a3fcabab5a4e