### PR TITLE
Add docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+models/
+model/
+__pycache__/
+.git/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ docker run -it darkrai
 
 Within the container you can run `darkrai` or execute the unit tests.
 
+### Using Docker Compose
+
+A `docker-compose.yml` is also provided for convenience. It builds the image
+while ignoring the optional `models` directory so that large checkpoints are not
+copied into the container.
+
+```bash
+# Build the image and start an interactive shell
+docker compose run --build darkrai
+```
+
 ### Dependencies
 
 Planned dependencies include:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  darkrai:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    command: bash


### PR DESCRIPTION
## Summary
- add docker-compose configuration for running Darkrai
- ignore heavy model directories when building the image
- document docker-compose usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecde56814832b8e833c9ef7d28b00