### PR TITLE
Add LlamaIndex vector store option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ darkrai generate "<prompt>" --output world.json
 
 This will request world data from the Mistral LLM, then save the JSON output to `world.json`.
 
+If you want to persist the generated world in a vector store managed by
+LlamaIndex, provide an additional directory with `--index`:
+
+```bash
+darkrai generate "<prompt>" --output world.json --index index_dir
+```
+
 ---
 
 This project is in its early stages, and contributions are welcome as we work toward a fully functional generator.

--- a/src/darkrai/cli.py
+++ b/src/darkrai/cli.py
@@ -26,6 +26,10 @@ def _cmd_generate(args: argparse.Namespace) -> None:
         json.dump(world, sys.stdout, indent=2)
         sys.stdout.write("\n")
 
+    if args.index:
+        from .index import store_world_in_index
+        store_world_in_index(world, args.index)
+
 
 def _cmd_download(args: argparse.Namespace) -> None:
     from huggingface_hub import snapshot_download, login
@@ -55,6 +59,7 @@ def main(argv: list[str] | None = None) -> None:
     gen.add_argument("--api-key", help="Mistral API key")
     gen.add_argument("--model", default="mistral-7b", help="Model name")
     gen.add_argument("--checkpoint", help="Path to local checkpoint")
+    gen.add_argument("--index", help="Directory to store a LlamaIndex vector store")
     gen.set_defaults(func=_cmd_generate)
 
     dl = subparsers.add_parser("download", help="Download model from Hugging Face")

--- a/src/darkrai/index.py
+++ b/src/darkrai/index.py
@@ -1,0 +1,46 @@
+"""Utility to store generated worlds in a LlamaIndex vector store."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def store_world_in_index(world: Dict[str, Any], index_dir: str) -> None:
+    """Persist the given ``world`` into a LlamaIndex vector store.
+
+    Parameters
+    ----------
+    world:
+        Dictionary describing the world.
+    index_dir:
+        Directory where the vector index will be persisted.
+
+    The ``llama-index`` package must be installed. If it is not available,
+    a ``RuntimeError`` is raised.
+    """
+
+    try:
+        from llama_index import (
+            VectorStoreIndex,
+            StorageContext,
+            load_index_from_storage,
+            Document,
+        )
+    except ImportError as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError("llama-index is required to store worlds") from exc
+
+    path = Path(index_dir)
+    path.mkdir(parents=True, exist_ok=True)
+
+    text = json.dumps(world, ensure_ascii=False)
+    doc = Document(text=text)
+
+    if any(path.iterdir()):
+        storage = StorageContext.from_defaults(persist_dir=str(path))
+        index = load_index_from_storage(storage)
+        index.insert(doc)
+    else:
+        index = VectorStoreIndex.from_documents([doc])
+
+    index.storage_context.persist(persist_dir=str(path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+# Provide a minimal stub for the llama_cpp module so that imports succeed
+module = types.ModuleType("llama_cpp")
+class DummyLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, prompt: str, **kwargs):
+        return {"choices": [{"text": ""}]}
+module.Llama = DummyLlama
+sys.modules.setdefault("llama_cpp", module)
+
+# Minimal requests stub
+requests_module = types.ModuleType("requests")
+class DummyResponse:
+    def __init__(self, json_data=None):
+        self._json = json_data or {}
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._json
+class DummySession:
+    def post(self, *args, **kwargs):
+        return DummyResponse({"choices": [{"message": {"content": ""}}]})
+requests_module.Session = DummySession
+sys.modules.setdefault("requests", requests_module)
+
+# Minimal transformers stub
+transformers_module = types.ModuleType("transformers")
+class Dummy:
+    pass
+transformers_module.AutoTokenizer = Dummy
+transformers_module.AutoModelForCausalLM = Dummy
+transformers_module.LlamaTokenizerFast = Dummy
+transformers_module.LlamaTokenizer = Dummy
+sys.modules.setdefault("transformers", transformers_module)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from darkrai.index import store_world_in_index
+
+
+def test_store_world_requires_llama_index(tmp_path):
+    index_dir = tmp_path / "index"
+    with pytest.raises(RuntimeError):
+        store_world_in_index({"name": "test"}, str(index_dir))


### PR DESCRIPTION
## Summary
- add new `store_world_in_index` helper for saving generated worlds to a LlamaIndex vector store
- support `--index` option in CLI to persist index
- document the new option in README
- add minimal stubs for heavy dependencies to allow tests in this environment
- test that the helper raises an error if `llama-index` is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515ac786bc832b9bd2592a07b53324